### PR TITLE
Fixes a possible nulling issue

### DIFF
--- a/1.12.2/src/main/java/net/creeperhost/minetogether/EventHandler.java
+++ b/1.12.2/src/main/java/net/creeperhost/minetogether/EventHandler.java
@@ -258,6 +258,8 @@ public class EventHandler
         } else if (gui instanceof GuiMultiplayer && !(gui instanceof GuiMultiplayerPublic) && lastInitialized != gui)
         {
             GuiMultiplayer mpGUI = (GuiMultiplayer) gui;
+			if (CreeperHost.instance.getImplementation() == null)
+				CreeperHost.instance.setRandomImplementation();
             if (Config.getInstance().isMpMenuEnabled() && CreeperHost.instance.getImplementation() != null)
             {
                 try

--- a/1.7.10/src/main/java/net/creeperhost/minetogether/EventHandler.java
+++ b/1.7.10/src/main/java/net/creeperhost/minetogether/EventHandler.java
@@ -177,6 +177,8 @@ public class EventHandler
         else if (gui instanceof GuiMultiplayer && !(gui instanceof GuiMultiplayerPublic) && lastInitialized != gui)
         {
             GuiMultiplayer mpGUI = (GuiMultiplayer) gui;
+			if (CreeperHost.instance.getImplementation() == null)
+				CreeperHost.instance.setRandomImplementation();
             if (Config.getInstance().isMpMenuEnabled() && CreeperHost.instance.getImplementation() != null)
             {
                 try


### PR DESCRIPTION
If main menu is not enabled, then the implementation doesn't get randomized.
In turn, the implementation is null, and so the multiplayers screen will not
render due to this. So we attempt to grab an implementation if it's still null.