### PR TITLE
fix incompatibility with mods that JIJ jackson rather than relocating it

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -68,7 +68,6 @@ processResources {
 shadowJar {
     exclude "fabric.mod.json"
     exclude "architectury.common.json"
-
     configurations = [project.configurations.shadowCommon]
     // Don't shadow netty, we already have it.
     dependencies {
@@ -83,6 +82,7 @@ shadowJar {
     relocate 'com.fasterxml.jackson', 'net.creeperhost.minetogether.com.fasterxml.jackson'
     relocate 'io.sentry', 'net.creeperhost.minetogether.io.sentry'
 
+    mergeServiceFiles()
 //    classifier '' // Replace the default JAR
     classifier "dev-shadow"
 }


### PR DESCRIPTION
shadowJar does not 'relocate' service files by default, which causes a ResolutionException on startup in forge when another mod includes the actual jackson JAR via JIJ because Minetogether incorrectly contains the service files for the bona-fide jackson package rather than the relocated version.

This issue does not affect fabric.